### PR TITLE
fix redefinition issue

### DIFF
--- a/acism_create.c
+++ b/acism_create.c
@@ -25,8 +25,19 @@ typedef struct tnode {
     SYMBOL sym, is_suffix;
 } TNODE;
 
+//--------------|---------------------------------------------
+// bitwid: 1+floor(log2(u))
+static inline int bitwid(unsigned u)
+{
+    int ret = !!u;
+    if (u & 0xFFFF0000) u >>= 16, ret += 16;
+    if (u & 0x0000FF00) u >>= 8, ret += 8;
+    if (u & 0x000000F0) u >>= 4, ret += 4;
+    if (u & 0x0000000C) u >>= 2, ret += 2;
+    if (u & 0x00000002) ret++;
+    return ret;
+}
 static void add_backlinks(TNODE*, TNODE**, TNODE**);
-static int bitwid(unsigned u);
 static int create_tree(TNODE*, SYMBOL const*symv, MEMREF const*strv, int nstrs);
 static void fill_hashv(ACISM*, TNODE const*, int nn);
 static void fill_symv(ACISM*, MEMREF const*, int ns);
@@ -116,18 +127,6 @@ acism_create(MEMREF const* strv, int nstrs)
 FAIL: acism_destroy(psp), psp = NULL;
 DONE: free(troot), free(v1), free(v2);
     return psp;
-}
-//--------------|---------------------------------------------
-// bitwid: 1+floor(log2(u))
-static inline int bitwid(unsigned u)
-{
-    int ret = !!u;
-    if (u & 0xFFFF0000) u >>= 16, ret += 16;
-    if (u & 0x0000FF00) u >>= 8, ret += 8;
-    if (u & 0x000000F0) u >>= 4, ret += 4;
-    if (u & 0x0000000C) u >>= 2, ret += 2;
-    if (u & 0x00000002) ret++;
-    return ret;
 }
 
 typedef struct { int freq, rank; } FRANK;


### PR DESCRIPTION
I'm using gcc 4.2 (i686-apple-darwin11-llvm-gcc-4.2) on mac OSX 10.7
I ran 

```
make CC=gcc
```

and got the following error message

```
gcc -g -MMD -fdiagnostics-show-option -fstack-protector --param ssp-buffer-size=4 -fno-strict-aliasing -Wall -Werror -Wextra -Wcast-align -Wcast-qual -Wformat=2 -Wformat-security -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Wno-unknown-pragmas -Wunused  -Wwrite-strings -Wno-attributes -O9 -mtune=native -I/usr/local/include -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE   -c -o acism.o acism.c
gcc -g -MMD -fdiagnostics-show-option -fstack-protector --param ssp-buffer-size=4 -fno-strict-aliasing -Wall -Werror -Wextra -Wcast-align -Wcast-qual -Wformat=2 -Wformat-security -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Wno-unknown-pragmas -Wunused  -Wwrite-strings -Wno-attributes -O9 -mtune=native -I/usr/local/include -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE   -c -o acism_create.o acism_create.c
cc1: warnings being treated as errors
acism_create.c:29: warning: ‘bitwid’ declared inline after being called
acism_create.c:29: warning: previous declaration of ‘bitwid’ was here
make: *** [acism_create.o] Error 1
```

looking at the source, `bitwid` is declared at line 29 but then is redeclared as inline at line 122, which my compiler doesn't seem to like.  Removing the original definition and moving the inline implementation up fixed the issue
