### PR TITLE
Fix compilation on Mac OS X 10.9.3 (Xcode 5.1.1)

### DIFF
--- a/acism_dump.c
+++ b/acism_dump.c
@@ -107,7 +107,10 @@ printrans(ACISM const*psp, STATE s, char const *charv,
     char c = charv[sym];
 
     //fprintf(out, !sym ? "--" : isprint(c) ? "'%c'" : "%02X ", c);
-    fprintf(out, !sym ? "--" : "%02X ", c);
+    if (sym)
+	fprintf(out, "--");
+    else
+	fprintf(out, "%02X ", c);
     putc("M-"[!(x & IS_MATCH)], out); putc("S-"[!(x & IS_SUFFIX)], out);
 
     STATE next = t_next(psp, x);

--- a/acism_file.c
+++ b/acism_file.c
@@ -59,7 +59,7 @@ acism_load(FILE *fp)
 ACISM*
 acism_mmap(FILE *fp)
 {
-    char *mp = mmap(0, lseek(fileno(fp), 0L, 2), PROT_READ,
+    ACISM *mp = mmap(0, lseek(fileno(fp), 0L, 2), PROT_READ,
                     MAP_SHARED|MAP_NOCORE, fileno(fp), 0);
     if (mp == MAP_FAILED) return NULL;
 
@@ -71,7 +71,7 @@ acism_mmap(FILE *fp)
         return NULL;
     }
 
-    set_tranv(psp, mp + sizeof(ACISM));
+    set_tranv(psp, ((char *)mp) + sizeof(ACISM));
     return psp;
 }
 

--- a/rules.mk
+++ b/rules.mk
@@ -32,7 +32,7 @@ PREFIX          ?= /usr/local
 DESTDIR         ?= $(PREFIX)
 OSNAME          := $(shell uname -s)
 
-CFLAGS.         = -O9
+CFLAGS.         = -O3
 
 CFLAGS.cover    = --coverage -DNDEBUG
 LDFLAGS.cover   = --coverage
@@ -53,6 +53,7 @@ Wno-unused-result := $(shell gcc -dumpversion | awk '$$0 >= 4.5 {print "-Wno-unu
 CFLAGS          += -g -MMD -fdiagnostics-show-option -fstack-protector --param ssp-buffer-size=4 -fno-strict-aliasing
 CFLAGS          += -Wall -Werror -Wextra -Wcast-align -Wcast-qual -Wformat=2 -Wformat-security -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Wno-unknown-pragmas -Wunused $(Wno-unused-result) -Wwrite-strings
 CFLAGS          += -Wno-attributes $(CFLAGS.$(BLD))
+CFLAGS          += -Wno-format-nonliteral
 
 # -D_FORTIFY_SOURCE=2 on some plats rejects any libc call whose return value is ignored.
 #   For some calls (system, write) this makes sense. For others (vasprintf), WTF?


### PR DESCRIPTION
Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)
