### PR TITLE
change return type of function p_size to size_t

### DIFF
--- a/_acism.h
+++ b/_acism.h
@@ -87,7 +87,7 @@ struct acism {
 #include "acism.h"
 
 // p_size: size of tranv + hashv
-static inline unsigned p_size(ACISM const *psp)
+static inline size_t p_size(ACISM const *psp)
 { return psp->hash_size * sizeof*psp->hashv
        + psp->tran_size * sizeof*psp->tranv; }
 


### PR DESCRIPTION
the function `p_size` prevent building trie model with very large size vocabularies, because of its return type.