### PR TITLE
Do not re-define ACISM_STATS if already set

### DIFF
--- a/acism.h
+++ b/acism.h
@@ -68,6 +68,8 @@ typedef enum {
 // If (pattv) is not NULL, dump output includes strings.
 void acism_dump(ACISM const*, PS_DUMP_TYPE, FILE*, MEMREF const*pattv);
 
+#ifndef ACISM_STATS
 #define ACISM_STATS 1   // Collect perf stats during acism_create (see acism_dump).
+#endif
 
 #endif//ACISM_H


### PR DESCRIPTION
@mischasan Do you think it would make sense to allow disabling `ACISM_STATS` when we want to get maximum perf from `acism_create`?