### PR TITLE
Added a shared-object (.so) target. Added case-insensitive searching.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,6 +12,7 @@ clean           += *.tmp
 
 #---------------- PRIVATE RULES:
 libacism.a      : acism.o  acism_create.o  acism_dump.o  acism_file.o
+libacism.so: acism.o  acism_create.o  acism_dump.o  acism_file.o
 acism_t.pass    : ${acism.x}  words
 ${acism.x}      : libacism.a  msutil.o  tap.o
 

--- a/_acism.h
+++ b/_acism.h
@@ -67,11 +67,17 @@ typedef struct { STATE state; STRNO strno; } STRASH;
 
 typedef enum { BASE=2, USED=1 } USES;
 
+typedef uint8_t (*char_mod_func)(const char character);
+uint8_t       char_mod_none(const char character);
+uint8_t       char_mod_upper(const char character);
+
 struct acism {
     TRAN*   tranv;
     STRASH* hashv;
+    char_mod_func char_mod;
     unsigned flags;
 #   define IS_MMAP 1
+#   define IS_CASE_SENSITIVE 2
 
 #if ACISM_SIZE < 8
     TRAN sym_mask;
@@ -116,5 +122,8 @@ static inline int t_strno(ACISM const *psp, TRAN t)
 
 static inline _SYMBOL t_valid(ACISM const *psp, TRAN t)
     { return !t_sym(psp, t); }
+
+static inline void assign_char_mod_func(ACISM *psp)
+    { psp->char_mod = psp->flags & IS_CASE_SENSITIVE ? char_mod_none : char_mod_upper; }
 
 #endif//_ACISM_H

--- a/acism.c
+++ b/acism.c
@@ -31,7 +31,7 @@ acism_more(ACISM const *psp, MEMREF const text,
     int ret = 0;
 
     while (cp < endp) {
-        _SYMBOL sym = psp->symv[(uint8_t)*cp++];
+        _SYMBOL sym = psp->symv[psp->char_mod(*cp++)];
         if (!sym) {
             // Input byte is not in any pattern string.
             state = ROOT;

--- a/acism.h
+++ b/acism.h
@@ -31,6 +31,7 @@ typedef struct { char const *ptr; size_t len; } MEMREF;
 typedef struct acism ACISM;
 
 ACISM* acism_create(MEMREF const *strv, int nstrs);
+ACISM* acism_create_full(MEMREF const *strv, int nstrs, unsigned case_sensitive);
 void   acism_destroy(ACISM*);
 
 // For each match, acism_scan calls its ACISM_ACTION fn,

--- a/acism_file.c
+++ b/acism_file.c
@@ -49,6 +49,7 @@ acism_load(FILE *fp)
             && !memcmp(psp, "ACMischa", 8)
             && (set_tranv(psp, malloc(p_size(psp))), 1)
             && fread(psp->tranv, p_size(psp), 1, fp)) {
+        assign_char_mod_func(psp);
         return psp;
     }
 
@@ -66,6 +67,7 @@ acism_mmap(FILE *fp)
     ACISM *psp = malloc(sizeof*psp);
     *psp = *(ACISM*)mp;
     psp->flags |= IS_MMAP;
+    assign_char_mod_func(psp);
     if (memcmp(psp, "ACMischa", 8)) {
         acism_destroy(psp);
         return NULL;


### PR DESCRIPTION
This change adds a function-pointer to the ACISM struct which is called for every char processed, be it while adding patterns or performing matching with acism_more. Normally this function does nothing except cast the char to uint8_t, but if ascim_create_full is called with a third argument of 0 then all patterns and string chars are made uppercase as they are processed (the original char is left unchanged). This allows case-insensitive matching of patterns, and may reduce the number of active states, depending on the patterns being searched for. It does slightly increase runtime of ascim_more and ascim_create, but it is also more flexible for ASCII searching.

As I have changed the ACISM struct, previously written out ACISM files will not work, they would have to be regenerated. I added a thin implementation of acism_create which calls acism_create_full with a third argument of 1, to recreate original behaviour.

I also added a shared-object (.so) target which can be dynamically linked instead of statically linked.